### PR TITLE
Add type field to avoid panic caused by nil map.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.idea
 /build
-
+.venv
 .DS_Store
 /logs
 /nvidiagpubeat

--- a/nvidia/gpu.go
+++ b/nvidia/gpu.go
@@ -67,6 +67,7 @@ func (g Utilization) run(cmd *exec.Cmd, gpuCount int, query string, action Actio
 		event := common.MapStr{
 			"@timestamp": common.Time(time.Now()),
 			"gpuIndex":   gpuIndex,
+			"type":   "nvidiagpubeat",
 		}
 		for i := 0; i < len(record); i++ {
 			value, _ := strconv.Atoi(record[i])

--- a/nvidia/gpu_test.go
+++ b/nvidia/gpu_test.go
@@ -1,7 +1,6 @@
 package nvidia
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
@@ -32,11 +31,11 @@ func Test_Command_ProdEnv(t *testing.T) {
 	}
 
 	if cmd.Args[1] != "--query-gpu=myquery" {
-		t.Errorf("Expected %s, Actual %s", "--query-gpu=myquery", cmd.Args[0])
+		t.Errorf("Expected %s, Actual %s", "--query-gpu=myquery", cmd.Args[1])
 	}
 
 	if cmd.Args[2] != "--format=csv" {
-		t.Errorf("Expected %s, Actual %s", "--format=csv", cmd.Args[0])
+		t.Errorf("Expected %s, Actual %s", "--format=csv", cmd.Args[2])
 	}
 }
 
@@ -56,7 +55,7 @@ func Test_Run_ProdEnv(t *testing.T) {
 	util := NewUtilization()
 	query := "utilization.gpu,utilization.memory,memory.total,memory.free,memory.used,temperature.gpu,pstate"
 	cmd := util.command("prod", query)
-	fmt.Println(cmd.Path)
+	t.Logf("Command: %s", cmd.Path)
 	output, _ := util.run(cmd, 4, query, MockLocal{})
 
 	for _, o := range output {
@@ -64,5 +63,20 @@ func Test_Run_ProdEnv(t *testing.T) {
 			t.Errorf("output cannot be nil.")
 		}
 	}
+}
 
+func Test_Event_Contains_Type_Field(t *testing.T) {
+	util := NewUtilization()
+	query := "utilization.gpu,utilization.memory,memory.total,memory.free,memory.used,temperature.gpu,pstate"
+	cmd := util.command("prod", query)
+	t.Logf("Command: %s", cmd.Path)
+
+	output, _ := util.run(cmd, 4, query, MockLocal{})
+	t.Logf("Nr. of Events: %d", len(output))
+
+	for _, o := range output {
+		if o["type"] != "nvidiagpubeat" {
+			t.Errorf("event does not contain 'type' field equal to 'nvidiagpubeat'")
+		}
+	}
 }

--- a/nvidiagpubeat.template-es2x.json
+++ b/nvidiagpubeat.template-es2x.json
@@ -89,6 +89,11 @@
           "ignore_above": 1024,
           "index": "not_analyzed",
           "type": "string"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "index": "not_analyzed",
+          "type": "string"
         }
       }
     }

--- a/nvidiagpubeat.template.json
+++ b/nvidiagpubeat.template.json
@@ -76,6 +76,10 @@
         "tags": {
           "ignore_above": 1024,
           "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
         }
       }
     }


### PR DESCRIPTION
Fixes #3; fixes #4.

The beats I have in my vendor folder use the event["type"] that supposedly shouldn't be used anymore.

I force "nvidiagpubeat" as type sent in the event. I also patched the templates.

It's my first time to work on beats code so I'm ready to be guided to fix/improve this PR.