### PR TITLE
Set up for CircleCI

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.7
+
+# Install virtualenv
+RUN curl https://bootstrap.pypa.io/get-pip.py | python
+RUN pip install virtualenv
+
+# Install glide
+RUN curl https://glide.sh/get | sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ references:
     docker:
       - image: rentziass/nvidiagpubeat_ci
         environment:
-          - WORKSPACE: /beats_test
           - GOPATH: /beats_test
 
   clone_elastic_beats: &clone_elastic_beats
@@ -20,21 +19,19 @@ references:
 
 jobs:
   build:
+    working_directory: /beats_test/src/github.com/deepujain/nvidiagpubeat
     <<: *container_config
     steps:
       - *clone_elastic_beats
-      - *clone_nvidiagpubeat
-
+      - checkout
       - run:
           name: Make
           command: |
-            cd ${GOPATH}/src/github.com/deepujain/nvidiagpubeat
             make
 
       - run:
           name: Unit tests
           command: |
-            cd ${GOPATH}/src/github.com/deepujain/nvidiagpubeat
             make unit-tests
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2
+
+references:
+  container_config: &container_config
+    docker:
+      - image: rentziass/nvidiagpubeat_ci
+        environment:
+          - WORKSPACE: /beats_test
+          - GOPATH: /beats_test
+
+  clone_elastic_beats: &clone_elastic_beats
+    run:
+      name: Clone github.com/elastic/beats
+      command: git clone https://github.com/elastic/beats ${GOPATH}/src/github.com/elastic/beats
+
+  clone_nvidiagpubeat: &clone_nvidiagpubeat
+    run:
+      name: Clone github.com/deepujain/nvidiagpubeat
+      command: git clone https://github.com/deepujain/nvidiagpubeat ${GOPATH}/src/github.com/deepujain/nvidiagpubeat
+
+jobs:
+  build:
+    <<: *container_config
+    steps:
+      - *clone_elastic_beats
+      - *clone_nvidiagpubeat
+
+      - run:
+          name: Make
+          command: |
+            cd ${GOPATH}/src/github.com/deepujain/nvidiagpubeat
+            make
+
+      - run:
+          name: Unit tests
+          command: |
+            cd ${GOPATH}/src/github.com/deepujain/nvidiagpubeat
+            make unit-tests
+
+workflows:
+  version: 2
+  continuous-integration:
+    jobs:
+      - build


### PR DESCRIPTION
This includes configuration to set up continuous integration for the project on CircleCI (addresses #6). [Example build](https://circleci.com/gh/rentziass/nvidiagpubeat/9)

It also includes the `Dockerfile` for the image that's being used to build the project, currently hosted under my profile on [Docker Hub](https://hub.docker.com/r/rentziass/nvidiagpubeat_ci/) but that can easily be moved when/if this PR gets merged, so that everything can sit under the same scope.

All of this can be certainly improved but it's a start at least.

To run this PR on CircleCI it would need @deepujain to just [add the project](https://circleci.com/add-projects/gh/deepujain) there, let me know if you need any help with that!